### PR TITLE
Update middleware to include additional public API routes

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,6 +1,12 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
-const isPublicRoute = createRouteMatcher(["/sign-in(.*)", "/sign-up(.*)", "/"]);
+const isPublicRoute = createRouteMatcher([
+  "/sign-in(.*)",
+  "/sign-up(.*)",
+  "/",
+  "/api/transcribe",
+  "/api/analyze-tiktok",
+]);
 
 export default clerkMiddleware(async (auth, req) => {
   if (!isPublicRoute(req)) {


### PR DESCRIPTION
- Expanded the public route matcher to include "/api/transcribe" and "/api/analyze-tiktok", allowing unauthenticated access to these endpoints.